### PR TITLE
Auto install SQL query

### DIFF
--- a/INSTALL.sql
+++ b/INSTALL.sql
@@ -1,1 +1,0 @@
-ALTER TABLE orders ADD downloaded_ship ENUM( 'yes', 'no' ) NOT NULL DEFAULT 'no';

--- a/README.md
+++ b/README.md
@@ -31,12 +31,11 @@ bulk printing of labels, bulk printing of envelopes, etc., you get the idea.
 _ _Install / Upgrade for zc 1.5.8+
 ===============================
 1	If you have installed a previous version on zc 1.5.8 look at your master copy and remove all of the files.
-	Copy the v1.5.8/zc-plugins folder to your site
+	Copy the ../zc-plugins folder to your site
 	Log into Admin > Modules > Plugin Manager locate Export Shipping & Order Information and install
 
 2	New Install
-	Copy the v1.5.8/zc-plugins folder to your site
-	Log into Admin and run the install.sql files through admin > Tools > Install SQL Patches
+	Copy the ../zc-plugins folder to your site
 	Log into Admin > Modules > Plugin Manager locate Export Shipping & Order Information and install
 
 3. Enjoy!

--- a/readme.txt
+++ b/readme.txt
@@ -31,12 +31,11 @@ bulk printing of labels, bulk printing of envelopes, etc., you get the idea.
 _ _Install / Upgrade for zc 1.5.8+
 ===============================
 1	If you have installed a previous version on zc 1.5.8 look at your master copy and remove all of the files.
-	Copy the v1.5.8/zc-plugins folder to your site
+	Copy the ../zc-plugins folder to your site
 	Log into Admin > Modules > Plugin Manager locate Export Shipping & Order Information and install
 
 2	New Install
-	Copy the v1.5.8/zc-plugins folder to your site
-	Log into Admin and run the install.sql files through admin > Tools > Install SQL Patches
+	Copy the ../zc-plugins folder to your site
 	Log into Admin > Modules > Plugin Manager locate Export Shipping & Order Information and install
 
 3. Enjoy!

--- a/zc_plugins/ExportShippingInformation/v1.5.3/Installer/ScriptedInstaller.php
+++ b/zc_plugins/ExportShippingInformation/v1.5.3/Installer/ScriptedInstaller.php
@@ -5,13 +5,20 @@ class ScriptedInstaller extends ScriptedInstallBase
 {
     protected function executeInstall()
     {
+        global $sniffer;
+        
         zen_deregister_admin_pages(['shipping_export2']);
         zen_register_admin_page(
             'shipping_export2', 'BOX_TOOLS_SHIPPING_EXPORT2', 'FILENAME_SHIPPING_EXPORT2', '', 'tools', 'Y');
+
+        if ($sniffer->field_exists(TABLE_ORDERS, 'downloaded_ship') !== true) {
+        $this->executeInstallerSql("ALTER TABLE " . TABLE_ORDERS . " ADD downloaded_ship ENUM( 'yes', 'no' ) NOT NULL DEFAULT 'no'");
+        }
     }
 
     protected function executeUninstall()
     {
         zen_deregister_admin_pages(['shipping_export2']);
+        //$this->executeInstallerSql("ALTER TABLE " . TABLE_ORDERS . " DROP COLUMN downloaded_ship"); // Uncomment if you want to delete this extra field when uninstalling. Data in this column will be lost.
     }
 }


### PR DESCRIPTION
This modification to installer will automatically install the new column `downloaded_ship` in `orders` table if necessary.